### PR TITLE
Update variables parameter to correctly parse query variables

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -23,7 +23,7 @@ functions:
               application/json: |
                 {
                   "query" : "$util.escapeJavaScript($input.path('$.query'))",
-                  "variables" : "$util.escapeJavaScript($input.path('$.variables'))",
+                  "variables" : $input.json('$.variables'),
                   "operationName" : "$util.escapeJavaScript($input.path('$.operationName'))",
                   "headers" : {
                      #if( $input.params().header.get('Authorization').toString() != "" )


### PR DESCRIPTION
When trying to query against a serverless postgraphql instance, I ran into an issue using query variables. Queries that worked as intended with hardcoded data would fail with no error message when refactored to use variables. I investigated the messages that were being sent and found the issue was with the way it was being parsed in serverless.yml. I updated the parameter to use json instead.

See issue #1 